### PR TITLE
kubectl creates service with selector app=NAME.

### DIFF
--- a/09-allow-traffic-only-to-a-port-number.md
+++ b/09-allow-traffic-only-to-a-port-number.md
@@ -15,7 +15,7 @@ ingress rules, the rule applies to all port numbers.
 
 Run a web server deployment called `apiserver`:
 
-    kubectl run apiserver --image=ahmet/app-on-two-ports --labels=app=api
+    kubectl run apiserver --image=ahmet/app-on-two-ports --labels=app=apiserver
 
 This application returns a hello response to requests on `http://:8000/`
 and a monitoring metrics response on `http://:5000/metrics`.
@@ -44,7 +44,7 @@ metadata:
 spec:
   podSelector:
     matchLabels:
-      app: api
+      app: apiserver
   ingress:
   - ports:
     - port: 5000
@@ -61,7 +61,7 @@ networkpolicy "api-allow-5000" created
 
 This network policy will:
 
-- Drop all non-whitelisted traffic to `app=api`.
+- Drop all non-whitelisted traffic to `app=apiserver`.
 - Allow traffic on port `5000` from pods with label
   `role=monitoring` in the same namespace.
 


### PR DESCRIPTION
```
$ kubectl create service clusterip apiserver --tcp 8001:8000 --tcp 5001:5000
$ kubectl get services --all-namespaces -o wide
NAMESPACE     NAME          TYPE        CLUSTER-IP       EXTERNAL-IP PORT(S)             AGE       SELECTOR
default       apiserver     ClusterIP   10.104.226.127   <none>      8001/TCP,5001/TCP   5m        app=apiserver
...
```
This is for:
```
$ kubectl version
Client Version: version.Info{Major:"1", Minor:"8", GitVersion:"v1.8.1", GitCommit:"f38e43b221d08850172a9a4ea785a86a3ffa3b3a", GitTreeState:"clean", BuildDate:"2017-10-11T23:27:35Z", GoVersion:"go1.8.3", Compiler:"gc", Platform:"linux/amd64"}
Server Version: version.Info{Major:"1", Minor:"8", GitVersion:"v1.8.7", GitCommit:"b30876a5539f09684ff9fde266fda10b37738c9c", GitTreeState:"clean", BuildDate:"2018-01-16T21:52:38Z", GoVersion:"go1.8.3", Compiler:"gc", Platform:"linux/amd64"}
```