### PR TITLE
Fix 01-deny-all-traffic-to-an-application.md typo

### DIFF
--- a/01-deny-all-traffic-to-an-application.md
+++ b/01-deny-all-traffic-to-an-application.md
@@ -45,7 +45,7 @@ spec:
 
 ```
 $ kubectl apply -f web-deny-all.yaml
-networkpolicy "access-nginx" created
+networkpolicy "web-deny-all" created
 ```
 
 ## Try it out


### PR DESCRIPTION
## 01-deny-all-traffic-to-an-application.md
My output on `kubectl apply -f web-deny-all.yaml`:

```
developer@Developer-Sierra-insira-identificador-9 /tmp $ kubectl apply -f web-deny-all.yaml                                                                                                                                                  [ruby-2.0.0p648]
networkpolicy "web-deny-all" created
```

instead of (as documented):

```
$ kubectl apply -f web-deny-all.yaml
networkpolicy "access-nginx" created
```


Thanksssss :)