### PR TITLE
Update 09-allow-traffic-only-to-a-port.md

### DIFF
--- a/09-allow-traffic-only-to-a-port.md
+++ b/09-allow-traffic-only-to-a-port.md
@@ -83,7 +83,7 @@ wget: download timed out
 ```
 
 Run a pod with `role=monitoring` label, observe the traffic to
-port 5001 is allowed, but port 8001 is still not accessible:
+port 5000 is allowed, but port 8000 is still not accessible:
 
 
 ```sh


### PR DESCRIPTION
Between the two examples, you mixed up services and containers ports confusing the guide for no reason. Altered the ports to reflect to match the terminology example.