### PR TITLE
cleaning up example

### DIFF
--- a/04-deny-traffic-from-other-namespaces.md
+++ b/04-deny-traffic-from-other-namespaces.md
@@ -36,8 +36,7 @@ metadata:
   namespace: secondary
   name: deny-from-other-namespaces
 spec:
-  podSelector:
-    matchLabels:
+  podSelector: {}
   ingress:
   - from:
     - podSelector: {}


### PR DESCRIPTION
Just to make the example more consistent.
So we use {} also for the podSelector and there is no need to use matchLabels.