### PR TITLE
Use run-pod/v1 in kubectl run command for 04-deny-traffic-from-other-namespaces.md

### DIFF
--- a/04-deny-traffic-from-other-namespaces.md
+++ b/04-deny-traffic-from-other-namespaces.md
@@ -22,7 +22,7 @@ Create a new namespace called `secondary` and start a web service:
 ```sh
 kubectl create namespace secondary
 
-kubectl run web --namespace secondary --image=nginx \
+kubectl run --generator=run-pod/v1 web --namespace secondary --image=nginx \
     --labels=app=web --expose --port 80
 ```
 
@@ -61,7 +61,7 @@ Note a few things about this manifest:
 Query this web service from the `default` namespace:
 
 ```sh
-$ kubectl run test-$RANDOM --namespace=default --rm -i -t --image=alpine -- sh
+$ kubectl run --generator=run-pod/v1 test-$RANDOM --namespace=default --rm -i -t --image=alpine -- sh
 / # wget -qO- --timeout=2 http://web.secondary
 wget: download timed out
 ```
@@ -71,7 +71,7 @@ It blocks the traffic from `default` namespace!
 Any pod in `secondary` namespace should work fine:
 
 ```sh
-$ kubectl run test-$RANDOM --namespace=secondary --rm -i -t --image=alpine -- sh
+$ kubectl run --generator=run-pod/v1 test-$RANDOM --namespace=secondary --rm -i -t --image=alpine -- sh
 / # wget -qO- --timeout=2 http://web.secondary
 <!DOCTYPE html>
 <html>

--- a/04-deny-traffic-from-other-namespaces.md
+++ b/04-deny-traffic-from-other-namespaces.md
@@ -79,7 +79,7 @@ $ kubectl run --generator=run-pod/v1 test-$RANDOM --namespace=secondary --rm -i 
 
 ### Cleanup
 
-    kubectl delete deployment web -n secondary
+    kubectl delete pod web -n secondary
     kubectl delete service web -n secondary
     kubectl delete networkpolicy deny-from-other-namespaces -n secondary
     kubectl delete namespace secondary


### PR DESCRIPTION
Replace deprecated `deployment/v1` with `run-pod/v1` for 04-deny-traffic-from-other-namespaces.md to suppress the following warning:
```
kubectl run --generator=deployment/apps.v1 is DEPRECATED and will be removed in a future version. Use kubectl run --generator=run-pod/v1 or kubectl create instead.
```