### PR TITLE
Updated kubectl run command as per v1.18

### DIFF
--- a/01-deny-all-traffic-to-an-application.md
+++ b/01-deny-all-traffic-to-an-application.md
@@ -17,11 +17,11 @@ application, selected using Pod Selectors.
 
 Run a nginx Pod with labels `app=web`  and expose it at port 80:
 
-    kubectl run --generator=run-pod/v1 web --image=nginx --labels app=web --expose --port 80
+    kubectl run web --image=nginx --labels app=web --expose --port 80
 
 Run a temporary Pod and make a request to `web` Service:
 
-    $ kubectl run --generator=run-pod/v1 --rm -i -t --image=alpine test-$RANDOM -- sh
+    $ kubectl run --rm -i -t --image=alpine test-$RANDOM -- sh
     / # wget -qO- http://web
     <!DOCTYPE html>
     <html>
@@ -52,7 +52,7 @@ networkpolicy "web-deny-all" created
 
 Run a test container again, and try to query web:
 
-    $ kubectl run --generator=run-pod/v1 --rm -i -t --image=alpine test-$RANDOM -- sh
+    $ kubectl run --rm -i -t --image=alpine test-$RANDOM -- sh
     / # wget -qO- --timeout=2 http://web
     wget: download timed out
 

--- a/02-limit-traffic-to-an-application.md
+++ b/02-limit-traffic-to-an-application.md
@@ -14,7 +14,7 @@ certain Pods.
 
 Suppose your application is a REST API server, marked with labels `app=bookstore` and `role=api`:
 
-    kubectl run --generator=run-pod/v1 apiserver --image=nginx --labels app=bookstore,role=api --expose --port 80
+    kubectl run apiserver --image=nginx --labels app=bookstore,role=api --expose --port 80
 
 Save the following NetworkPolicy to `api-allow.yaml` to restrict the access
 only to other pods (e.g. other microservices) running with label `app=bookstore`:
@@ -45,7 +45,7 @@ networkpolicy "api-allow" created
 
 Test the Network Policy is **blocking** the traffic, by running a Pod without the `app=bookstore` label:
 
-    $ kubectl run --generator=run-pod/v1 test-$RANDOM --rm -i -t --image=alpine -- sh
+    $ kubectl run test-$RANDOM --rm -i -t --image=alpine -- sh
     / # wget -qO- --timeout=2 http://apiserver
     wget: download timed out
 
@@ -53,7 +53,7 @@ Traffic is blocked!
 
 Test the Network Policy is **allowing** the traffic, by running a Pod with the `app=bookstore` label:
 
-    $ kubectl run --generator=run-pod/v1 test-$RANDOM --rm -i -t --image=alpine --labels app=bookstore,role=frontend -- sh
+    $ kubectl run test-$RANDOM --rm -i -t --image=alpine --labels app=bookstore,role=frontend -- sh
     / # wget -qO- --timeout=2 http://apiserver
     <!DOCTYPE html>
     <html><head>

--- a/02a-allow-all-traffic-to-an-application.md
+++ b/02a-allow-all-traffic-to-an-application.md
@@ -12,7 +12,7 @@ void, and allow all traffic to it from its namespace and other namespaces.
 
 Start a `web` application:
 
-    kubectl run --generator=run-pod/v1 web --image=nginx \
+    kubectl run web --image=nginx \
         --labels=app=web --expose --port 80
 
 Save the following manifest to `web-allow-all.yaml`:
@@ -56,7 +56,7 @@ that applying `web-allow-all` will make the `web-deny-all` void.
 
 ### Try it out
 
-    $ kubectl run --generator=run-pod/v1 test-$RANDOM --rm -i -t --image=alpine -- sh
+    $ kubectl run test-$RANDOM --rm -i -t --image=alpine -- sh
     / # wget -qO- --timeout=2 http://web
     <!DOCTYPE html>
     <html><head>

--- a/04-deny-traffic-from-other-namespaces.md
+++ b/04-deny-traffic-from-other-namespaces.md
@@ -22,7 +22,7 @@ Create a new namespace called `secondary` and start a web service:
 ```sh
 kubectl create namespace secondary
 
-kubectl run --generator=run-pod/v1 web --namespace secondary --image=nginx \
+kubectl run web --namespace secondary --image=nginx \
     --labels=app=web --expose --port 80
 ```
 
@@ -61,7 +61,7 @@ Note a few things about this manifest:
 Query this web service from the `default` namespace:
 
 ```sh
-$ kubectl run --generator=run-pod/v1 test-$RANDOM --namespace=default --rm -i -t --image=alpine -- sh
+$ kubectl run test-$RANDOM --namespace=default --rm -i -t --image=alpine -- sh
 / # wget -qO- --timeout=2 http://web.secondary
 wget: download timed out
 ```
@@ -71,7 +71,7 @@ It blocks the traffic from `default` namespace!
 Any pod in `secondary` namespace should work fine:
 
 ```sh
-$ kubectl run --generator=run-pod/v1 test-$RANDOM --namespace=secondary --rm -i -t --image=alpine -- sh
+$ kubectl run test-$RANDOM --namespace=secondary --rm -i -t --image=alpine -- sh
 / # wget -qO- --timeout=2 http://web.secondary
 <!DOCTYPE html>
 <html>

--- a/05-allow-traffic-from-all-namespaces.md
+++ b/05-allow-traffic-from-all-namespaces.md
@@ -20,7 +20,7 @@ Create a new namespace called `secondary` and start a web service:
 ```sh
 kubectl create namespace secondary
 
-kubectl run --generator=run-pod/v1 web --image=nginx \
+kubectl run web --image=nginx \
     --namespace secondary \
     --labels=app=web --expose --port 80
 ```
@@ -71,7 +71,7 @@ Note a few things about this NetworkPolicy manifest:
 Query this web service from the `default` namespace:
 
 ```sh
-$ kubectl run --generator=run-pod/v1 test-$RANDOM --namespace=default --rm -i -t --image=alpine -- sh
+$ kubectl run test-$RANDOM --namespace=default --rm -i -t --image=alpine -- sh
 / # wget -qO- --timeout=2 http://web.secondary
 <!DOCTYPE html>
 <html>

--- a/06-allow-traffic-from-a-namespace.md
+++ b/06-allow-traffic-from-a-namespace.md
@@ -16,7 +16,7 @@ choose particular namespaces.
 
 Run a web server in the `default` namespace:
 
-    kubectl run --generator=run-pod/v1 web --image=nginx \
+    kubectl run web --image=nginx \
         --labels=app=web --expose --port 80
 
 Now, suppose you have these three namespaces:
@@ -67,7 +67,7 @@ networkpolicy "web-allow-prod" created
 Query this web server from `dev` namespace, observe it is blocked:
 
 ```sh
-$ kubectl run --generator=run-pod/v1 test-$RANDOM --namespace=dev --rm -i -t --image=alpine -- sh
+$ kubectl run test-$RANDOM --namespace=dev --rm -i -t --image=alpine -- sh
 If you don't see a command prompt, try pressing enter.
 / # wget -qO- --timeout=2 http://web.default
 wget: download timed out
@@ -78,7 +78,7 @@ wget: download timed out
 Query it from `prod` namespace, observe it is allowed:
 
 ```sh
-$ kubectl run --generator=run-pod/v1 test-$RANDOM --namespace=prod --rm -i -t --image=alpine -- sh
+$ kubectl run test-$RANDOM --namespace=prod --rm -i -t --image=alpine -- sh
 If you don't see a command prompt, try pressing enter.
 / # wget -qO- --timeout=2 http://web.default
 <!DOCTYPE html>

--- a/07-allow-traffic-from-some-pods-in-another-namespace.md
+++ b/07-allow-traffic-from-some-pods-in-another-namespace.md
@@ -11,7 +11,7 @@ deploy it to make sure it is working correctly.
 
 Start a `web` application:
 
-    kubectl run --generator=run-pod/v1 web --image=nginx \
+    kubectl run web --image=nginx \
         --labels=app=web --expose --port 80
 
 Create a `other` namespace and label it:
@@ -51,7 +51,7 @@ networkpolicy.networking.k8s.io/web-allow-all-ns-monitoring created
 Query this web server from `default` namespace, *without* labelling the application `type=monitoring`, observe it is **blocked**:
 
 ```sh
-$ kubectl run --generator=run-pod/v1 test-$RANDOM --rm -i -t --image=alpine -- sh
+$ kubectl run test-$RANDOM --rm -i -t --image=alpine -- sh
 If you don't see a command prompt, try pressing enter.
 / # wget -qO- --timeout=2 http://web.default
 wget: download timed out
@@ -62,7 +62,7 @@ wget: download timed out
 Query this web server from `default` namespace, labelling the application `type=monitoring`, observe it is **blocked**:
 
 ```sh
-kubectl run --generator=run-pod/v1 test-$RANDOM --labels type=monitoring --rm -i -t --image=alpine -- sh
+kubectl run test-$RANDOM --labels type=monitoring --rm -i -t --image=alpine -- sh
 If you don't see a command prompt, try pressing enter.
 / # wget -qO- --timeout=2 http://web.default
 wget: download timed out
@@ -73,7 +73,7 @@ wget: download timed out
 Query this web server from `other` namespace, *without* labelling the application `type=monitoring`, observe it is **blocked**:
 
 ```sh
-$ kubectl run --generator=run-pod/v1 test-$RANDOM --namespace=other --rm -i -t --image=alpine -- sh
+$ kubectl run test-$RANDOM --namespace=other --rm -i -t --image=alpine -- sh
 If you don't see a command prompt, try pressing enter.
 / # wget -qO- --timeout=2 http://web.default
 wget: download timed out
@@ -84,7 +84,7 @@ wget: download timed out
 Query this web server from `other` namespace, labelling the application `type=monitoring`, observe it is **allowed**:
 
 ```sh
-kubectl run --generator=run-pod/v1 test-$RANDOM --namespace=other --labels type=monitoring --rm -i -t --image=alpine -- sh
+kubectl run test-$RANDOM --namespace=other --labels type=monitoring --rm -i -t --image=alpine -- sh
 If you don't see a command prompt, try pressing enter.
 / # wget -qO- --timeout=2 http://web.default
 <!DOCTYPE html>

--- a/08-allow-external-traffic.md
+++ b/08-allow-external-traffic.md
@@ -15,7 +15,7 @@ or via a Load Balancer to access to the pod.
 Run a web server and expose it to the internet with a Load Balancer:
 
 ```sh
-kubectl run --generator=run-pod/v1 web --image=nginx \
+kubectl run web --image=nginx \
     --labels=app=web --port 80
 
 kubectl expose pod/web --type=LoadBalancer

--- a/09-allow-traffic-only-to-a-port.md
+++ b/09-allow-traffic-only-to-a-port.md
@@ -17,7 +17,7 @@ A port may be either a numerical or named port on a pod.
 
 Run a web server deployment called `apiserver`:
 
-    kubectl run --generator=run-pod/v1 apiserver --image=ahmet/app-on-two-ports --labels=app=apiserver
+    kubectl run apiserver --image=ahmet/app-on-two-ports --labels=app=apiserver
 
 This application returns a hello response to requests on `http://:8000/`
 and a monitoring metrics response on `http://:5000/metrics`.
@@ -74,7 +74,7 @@ Run a pod with no custom labels, observe the traffic to ports
 5000 and 8000 are blocked:
 
 ```sh
-$ kubectl run --generator=run-pod/v1 test-$RANDOM --rm -i -t --image=alpine -- sh
+$ kubectl run test-$RANDOM --rm -i -t --image=alpine -- sh
 / # wget -qO- --timeout=2 http://apiserver:8001
 wget: download timed out
 
@@ -87,7 +87,7 @@ port 5000 is allowed, but port 8000 is still not accessible:
 
 
 ```sh
-$ kubectl run --generator=run-pod/v1 test-$RANDOM --labels=role=monitoring --rm -i -t --image=alpine -- sh
+$ kubectl run test-$RANDOM --labels=role=monitoring --rm -i -t --image=alpine -- sh
 / # wget -qO- --timeout=2 http://apiserver:8001
 wget: download timed out
 

--- a/10-allowing-traffic-with-multiple-selectors.md
+++ b/10-allowing-traffic-with-multiple-selectors.md
@@ -10,7 +10,7 @@ NetworkPolicy lets you define multiple pod selectors to allow traffic from.
 
 Run a Redis database on your cluster:
 
-    kubectl run --generator=run-pod/v1 db --image=redis:4 --port 6379 --expose \
+    kubectl run db --image=redis:4 --port 6379 --expose \
         --labels app=bookstore,role=db
 
 Suppose you would like to share this Redis database between multiple
@@ -67,7 +67,7 @@ Note that:
 Run a pod that looks like the "catalog" microservice:
 
 ```sh
-$ kubectl run --generator=run-pod/v1 test-$RANDOM --labels=app=inventory,role=web --rm -i -t --image=alpine -- sh
+$ kubectl run test-$RANDOM --labels=app=inventory,role=web --rm -i -t --image=alpine -- sh
 
 / # nc -v -w 2 db 6379
 db (10.59.242.200:6379) open
@@ -78,7 +78,7 @@ db (10.59.242.200:6379) open
 Pods with labels not matching these microservices will not be able to connect:
 
 ```sh
-$ kubectl run --generator=run-pod/v1 test-$RANDOM --labels=app=other --rm -i -t --image=alpine -- sh
+$ kubectl run test-$RANDOM --labels=app=other --rm -i -t --image=alpine -- sh
 
 / # nc -v -w 2 db 6379
 nc: db (10.59.252.83:6379): Operation timed out

--- a/11-deny-egress-traffic-from-an-application.md
+++ b/11-deny-egress-traffic-from-an-application.md
@@ -15,7 +15,7 @@
 
 Run a web application with `app=web` label:
 
-    kubectl run --generator=run-pod/v1 web --image=nginx --port 80 --expose \
+    kubectl run web --image=nginx --port 80 --expose \
         --labels app=web
 
 Save the following to `foo-deny-egress.yaml` and apply to the cluster:
@@ -52,7 +52,7 @@ networkpolicy "foo-deny-egress" created
 Run a pod with label `app=foo`, and try to connect to the `web` service:
 
 ```sh
-$ kubectl run --generator=run-pod/v1 --rm --restart=Never --image=alpine -i -t -l app=foo test -- ash
+$ kubectl run --rm --restart=Never --image=alpine -i -t -l app=foo test -- ash
 
 / # wget -qO- --timeout 1 http://web:80/
 wget: bad address 'web:80'

--- a/14-deny-external-egress-traffic.md
+++ b/14-deny-external-egress-traffic.md
@@ -59,13 +59,13 @@ networkpolicy "foo-deny-egress" created
 
 Run a web application named `web`:
 
-    kubectl run --generator=run-pod/v1 web --image=nginx --port 80 --expose \
+    kubectl run web --image=nginx --port 80 --expose \
         --labels app=web
 
 Run a pod with label `app=foo`. The policy will be enforced on this pod:
 
 ```sh
-$ kubectl run --generator=run-pod/v1 --rm --restart=Never --image=alpine -i -t -l app=foo test -- ash
+$ kubectl run --rm --restart=Never --image=alpine -i -t -l app=foo test -- ash
 
 / # wget -O- --timeout 1 http://web:80
 Connecting to web (10.59.245.232:80)

--- a/14-deny-external-egress-traffic.md
+++ b/14-deny-external-egress-traffic.md
@@ -32,7 +32,7 @@ spec:
       protocol: UDP
     - port: 53
       protocol: TCP
-   to:
+    to:
     - namespaceSelector: {}
 ```
 


### PR DESCRIPTION
In section 09-allow-traffic-only-to-a-port, you wrote "Run a web server deployment called apiserver: " but In kubectl run command, used --generator=run-pod/v1 and it's create Pod. So i haven't changed that may be it's sound okay.

regards, 