### PR TITLE
fix misformatting of networkpolicy yaml

### DIFF
--- a/14-deny-external-egress-traffic.md
+++ b/14-deny-external-egress-traffic.md
@@ -32,7 +32,7 @@ spec:
       protocol: UDP
     - port: 53
       protocol: TCP
-   to:
+    to:
     - namespaceSelector: {}
 ```
 


### PR DESCRIPTION
the `to` field was one space off, which caused it to not be recognized as valid yaml