### PR TITLE
Error in "DENY external egress traffic" NetworkPolicy

### DIFF
--- a/14-deny-external-egress-traffic.md
+++ b/14-deny-external-egress-traffic.md
@@ -32,7 +32,7 @@ spec:
       protocol: UDP
     - port: 53
       protocol: TCP
-    to:
+  - to:
     - namespaceSelector: {}
 ```
 


### PR DESCRIPTION
Previous NetworkPolicy was not working as stated, it allowed only TCP/UDP :53 (DNS) in the cluster: 

![image](https://user-images.githubusercontent.com/8836773/98017924-99923680-1e08-11eb-8ec8-08c2022ce5ba.png)


Changed to correct version - allow to all TCP/UDP :53, and any outbound traffic in cluster:

![image](https://user-images.githubusercontent.com/8836773/98017826-78314a80-1e08-11eb-90be-61bee95ea024.png)


Test before:

```
kubectl run --generator=run-pod/v1 --rm --restart=Never --image=alpine -i -t -l app=foo test -- ash
Flag --generator has been deprecated, has no effect and will be removed in the future.
If you don't see a command prompt, try pressing enter.
/ # wget -O- --timeout 1 http://web:80
Connecting to web:80 (10.100.135.234:80)
wget: download timed out
/ # wget -O- --timeout 1 http://www.example.com
Connecting to www.example.com (93.184.216.34:80)
wget: download timed out
```



Test after:

```
kubectl run --generator=run-pod/v1 --rm --restart=Never --image=alpine -i -t -l app=foo test -- ash
Flag --generator has been deprecated, has no effect and will be removed in the future.
If you don't see a command prompt, try pressing enter.
/ # wget -O- --timeout 1 http://web:80
Connecting to web:80 (10.100.135.234:80)
writing to stdout
<!DOCTYPE html>
<html>
(Truncated)
/ # wget -O- --timeout 1 http://www.example.com
Connecting to www.example.com (93.184.216.34:80)
wget: download timed out
```
