### PR TITLE
Update 02a-allow-all-traffic-to-an-application.md

### DIFF
--- a/02a-allow-all-traffic-to-an-application.md
+++ b/02a-allow-all-traffic-to-an-application.md
@@ -37,11 +37,7 @@ A few remarks about this manifest:
 - `podSelector` applies the ingress rule to pods with `app: web`
 - Only one ingress rule is specified, and **it is empty**.
   - Empty ingress rule (`{}`) allows traffic from all pods in the current
-    namespace, as well as other namespaces. It corresponds to:
-
-        - from:
-            podSelector: {}
-            namespaceSelector: {}
+    namespace, as well as other namespaces. 
 
 Now apply it to the cluster:
 


### PR DESCRIPTION
adding empty pod and namespace selector  restricts the communications to all pods in the cluster but not to external world. So it is not same Allow all.