### PR TITLE
fix the allow-external-traffic

### DIFF
--- a/08-allow-external-traffic.md
+++ b/08-allow-external-traffic.md
@@ -39,7 +39,7 @@ spec:
     matchLabels:
       app: web
   ingress:
-  - from: []
+  - from: {}
 ```
 
 ```sh
@@ -63,7 +63,7 @@ such as:
   ingress:
   - ports:
     - port: 80
-    from: []
+    from: {}
 ```
 
 ### Cleanup


### PR DESCRIPTION
I would think the original configuration **from:[]** is to block all the ingress traffic