### PR TITLE
Remove warning, since PodSelector was narrowed

### DIFF
--- a/11-deny-egress-traffic-from-an-application.md
+++ b/11-deny-egress-traffic-from-an-application.md
@@ -117,9 +117,6 @@ PING google.com (74.125.129.101): 56 data bytes
 / # exit
 ```
 
-Beware that the egress rule above allows Pod to connect not only `kube-dns`,
-but any host that serves traffic over port `53`.
-
 ## Cleanup
 
 ```


### PR DESCRIPTION
due to #98, the warning is not necessary anymore