### PR TITLE
Fix ports egress 14-deny-external-egress-traffic.md

### DIFF
--- a/14-deny-external-egress-traffic.md
+++ b/14-deny-external-egress-traffic.md
@@ -34,7 +34,7 @@ spec:
       podSelector:
         matchLabels:
           k8s-app: kube-dns
-    ports:
+  - ports:
       - port: 53
         protocol: UDP
       - port: 53


### PR DESCRIPTION
The policy won't work if not having "- " in front of `ports`.