### PR TITLE
add an example of named port

### DIFF
--- a/09-allow-traffic-only-to-a-port.md
+++ b/09-allow-traffic-only-to-a-port.md
@@ -56,6 +56,22 @@ spec:
         matchLabels:
           role: monitoring
 ```
+A named port example would look like
+```yaml
+ingress:
+- ports:
+  - port: api-port
+```
+Assuming the pod spec looks like
+```yaml
+containers:
+- name: api
+  image: api-image:latest
+  ports:
+  - name: api-port
+    containerPort: 5000
+    protocol: TCP
+```
 
 ```sh
 $ kubectl apply -f api-allow-5000.yaml


### PR DESCRIPTION
add an example of named port to the [09-allow-traffic-only-to-a-port.md](https://github.com/ahmetb/kubernetes-network-policy-recipes/blob/master/09-allow-traffic-only-to-a-port.md) example

The request come in Issue https://github.com/ahmetb/kubernetes-network-policy-recipes/issues/108

Let me know if the code block makes sense or I should move it around or re-write it!